### PR TITLE
bump timestampvm version to 1.2.2

### DIFF
--- a/timestampvm/vm.go
+++ b/timestampvm/vm.go
@@ -31,7 +31,7 @@ const (
 var (
 	errNoPendingBlocks = errors.New("there is no block to propose")
 	errBadGenesisBytes = errors.New("genesis data should be bytes (max length 32)")
-	Version            = version.NewDefaultVersion(1, 2, 1)
+	Version            = version.NewDefaultVersion(1, 2, 2)
 
 	_ block.ChainVM = &VM{}
 )


### PR DESCRIPTION
a follow-up PR for #17 
bumps VM version to 1.2.2.