### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ TimestampVM defines a blockchain that is a timestamp server. Each block in the b
 [`scripts/run.sh`](scripts/run.sh) automatically installs [avalanchego], sets up a local network,
 and creates a `timestampvm` genesis file. To build and run E2E tests, you need to set the variable `E2E` before it: `E2E=true ./scripts/run.sh 1.7.11`
 
+*Note: the ginkgo testing tool is required to be present for the above script to run successfully. See [the installation instructions](https://onsi.github.io/ginkgo/#getting-started) for installing ginkgo on your machine if it is not already installed.*  
+
 _See [`tests/e2e`](tests/e2e) to see how it's set up and how its client requests are made._
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ TimestampVM defines a blockchain that is a timestamp server. Each block in the b
 [`scripts/run.sh`](scripts/run.sh) automatically installs [avalanchego], sets up a local network,
 and creates a `timestampvm` genesis file. To build and run E2E tests, you need to set the variable `E2E` before it: `E2E=true ./scripts/run.sh 1.7.11`
 
-*Note: the ginkgo testing tool is required to be present for the above script to run successfully. See [the installation instructions](https://onsi.github.io/ginkgo/#getting-started) for installing ginkgo on your machine if it is not already installed.*  
+*Note: The above script relies on ginkgo to run successfully. Ensure that $GOPATH/bin is part of your $PATH before running the script.*  
 
 _See [`tests/e2e`](tests/e2e) to see how it's set up and how its client requests are made._
 


### PR DESCRIPTION
Adds additional information on the ginkgo requirement. Without ginkgo, the run script fails, even if e2e tests are not specified. 

Most Go devs have ginkgo installed locally already, but it should be specified as a dependency in case one does not.

<img width="389" alt="image" src="https://user-images.githubusercontent.com/31546601/217023888-54704280-4030-47ac-822f-6fa8e86732c6.png">
